### PR TITLE
Updates in jackson directory

### DIFF
--- a/jackson/src/collection_and_trash/list_collection_test.lean
+++ b/jackson/src/collection_and_trash/list_collection_test.lean
@@ -9,7 +9,6 @@ def ns := [1,2,3]
 #eval collection.has_collection.member ns 1  -- expect tt
 #eval collection.has_collection.member ns 5  -- expect ff
 
-
 def insert_0 (
   l : list nat) 
   [collection.has_collection list] : 
@@ -26,4 +25,14 @@ begin
   exact rfl,    -- ⊢ insert_0 ns = [0, 1, 2, 3]
 end
 
+example : (insert_0 ns) = [0,1,2,3] :=
+begin
+  /-
+  The proof works if we add a long "simp only" statement.
+  Perhaps adding "@[simp]" before some of the definitions used 
+  here would simplify the proof further.
+  -/
+  simp only [ns, insert_0, has_collection.insert, do_insert, do_member],
+  exact rfl,
+end
 

--- a/jackson/src/concept/collection.lean
+++ b/jackson/src/concept/collection.lean
@@ -2,8 +2,6 @@ namespace collection
 
 universe u
 
-namespace collection
-
 class has_collection (collection_type : Type u → Type u) :=
 -- ACTIONS ("CONSTANTS AND OPERATIONS")
 -- empty/starting state for a collection
@@ -23,5 +21,4 @@ class has_collection (collection_type : Type u → Type u) :=
 
 -- LAWS ("operational principle")
 -- TBD
-]end collection 
 end collection

--- a/jackson/src/concept/trash.lean
+++ b/jackson/src/concept/trash.lean
@@ -18,19 +18,19 @@ def trash_state
   (trash_collection_type : Type u → Type u) 
   [collection.has_collection trash_collection_type]
   (item_type : Type u) [decidable_eq item_type] :=
-(available_collection_type item_type) × (available_collection_type item_type)
+(available_collection_type item_type) × (trash_collection_type item_type)
 
 
 def do_init 
   (available_collection_type : Type u → Type u)  
-  [c: collection.has_collection available_collection_type] 
+  [c₁ : collection.has_collection available_collection_type] 
   (trash_collection_type : Type u → Type u) 
-  [collection.has_collection trash_collection_type]
+  [c₂ : collection.has_collection trash_collection_type]
   (item_type : Type u) 
   [e : decidable_eq item_type] :=
 (
-  (@collection.has_collection.init available_collection_type c item_type e), 
-  (@collection.has_collection.init available_collection_type c item_type e)
+  (@collection.has_collection.init available_collection_type c₁ item_type e), 
+  (@collection.has_collection.init trash_collection_type c₂ item_type e)
 )
 
 

--- a/jackson/src/mod/contributing_factor.lean
+++ b/jackson/src/mod/contributing_factor.lean
@@ -1,0 +1,107 @@
+universe u
+
+inductive contributing_factor : Type u
+| patient_unnecessary_treatments : contributing_factor
+| patient_aggressive_treatment : contributing_factor
+| patient_unnecessary_suffering : contributing_factor
+| patient_inadequate_consent : contributing_factor
+| patient_false_hope : contributing_factor
+| patient_not_discuss_prognosis : contributing_factor
+| patient_other : contributing_factor
+| team_unclear_treatment : contributing_factor
+| team_lack_provider_continuity : contributing_factor
+| team_fearing_retribution : contributing_factor
+| team_not_competent : contributing_factor
+| team_fearing_litigation : contributing_factor
+| team_ignore_errors : contributing_factor
+| team_report_violation : contributing_factor
+| team_no_dignity_respect : contributing_factor
+| team_unsafe_bullied : contributing_factor
+| team_power_structures : contributing_factor
+| team_poor_communication : contributing_factor
+| team_inconsistent_messages : contributing_factor
+| team_other : contributing_factor
+| system_not_qualified : contributing_factor
+| system_more_patients_than_safe : contributing_factor
+| system_lack_admin_support : contributing_factor
+| system_work_with_abusive : contributing_factor
+| system_reduce_costs : contributing_factor
+| system_lack_resources : contributing_factor
+| system_excessive_documentation : contributing_factor
+| system_emphasize_productivity_measures : contributing_factor
+| system_other : contributing_factor
+
+namespace contributing_factor
+
+open contributing_factor
+
+inductive category : Type
+| patient
+| team
+| system
+
+open category
+
+def get_category : contributing_factor → category
+| patient_unnecessary_treatments := patient
+| patient_aggressive_treatment := patient
+| patient_unnecessary_suffering := patient
+| patient_inadequate_consent := patient
+| patient_false_hope := patient
+| patient_not_discuss_prognosis := patient
+| patient_other := patient
+| team_unclear_treatment := team
+| team_lack_provider_continuity := team
+| team_fearing_retribution := team
+| team_not_competent := team
+| team_fearing_litigation := team
+| team_ignore_errors := team
+| team_report_violation := team
+| team_no_dignity_respect := team
+| team_unsafe_bullied := team
+| team_power_structures := team
+| team_poor_communication := team
+| team_inconsistent_messages := team
+| team_other := team
+| system_not_qualified := system
+| system_more_patients_than_safe := system
+| system_lack_admin_support := system
+| system_work_with_abusive := system
+| system_reduce_costs := system
+| system_lack_resources := system
+| system_excessive_documentation := system
+| system_emphasize_productivity_measures := system
+| system_other := system
+
+def get_description : contributing_factor → string
+| patient_unnecessary_treatments := "Feeling pressured to give unnecessary/inappropriate test and/or treatments"
+| patient_aggressive_treatment := "Having to continue aggressive treatment not in the patient's best interest"
+| patient_unnecessary_suffering := "Causing unnecessary suffering or do not relieve pain/symptoms"
+| patient_inadequate_consent := "Ignoring situations of inadequate informed consent"
+| patient_false_hope := "Witnessing providers giving \"false hope\" to patients/families"
+| patient_not_discuss_prognosis := "Having to follow MD/family's request to not discuss prognosis"
+| team_unclear_treatment := "Seeing unclear/inconsistent treatment plans or goals of care"
+| team_lack_provider_continuity := "Witnessing lack of provider continuity"
+| team_fearing_retribution := "Fearing retribution if I speak up"
+| team_not_competent := "Witnessing other team members not competent in providing quality care"
+| team_fearing_litigation := "Fearing litigation"
+| team_ignore_errors := "Feeling pressured to ignore medical error(s)"
+| team_report_violation := "Feeling not supported enough to report a violation of procedure/ethics"
+| team_no_dignity_respect := "Working with teams who don't treat patients with dignity/respect"
+| team_unsafe_bullied := "Feeling unsafe/bullied amongst own colleagues"
+| team_power_structures := "Working within power structures that compromise patient care"
+| team_poor_communication := "Witnessing poor team communication"
+| team_inconsistent_messages := "Witnessing inconsistent messages to patient/family"
+| system_not_qualified := "Caring for patients not qualified to care for"
+| system_more_patients_than_safe := "Caring for more patients than is safe"
+| system_lack_admin_support := "Experiencing lack of administrative/managerial support"
+| system_work_with_abusive := "Feeling required to work with abusive patients/family members"
+| system_reduce_costs := "Feeling pressured from admin/insurers to reduce costs over patient care"
+| system_lack_resources := "Experiencing lack of resources/beds/equipment"
+| system_excessive_documentation := "Experiencing excessive documentation requirements"
+| system_emphasize_productivity_measures := "Feeling pressured to emphasize productivity/quality measures over patients"
+| _ := "Other"
+
+instance : has_repr contributing_factor := ⟨get_description⟩
+
+end contributing_factor

--- a/jackson/src/mod/mod_report.lean
+++ b/jackson/src/mod/mod_report.lean
@@ -1,0 +1,55 @@
+import .contributing_factor
+import ..concept.collection
+
+universe u
+
+structure time_utc : Type :=
+(seconds_since_start_of_epoch : ℕ)
+
+instance : has_repr time_utc := ⟨
+  λ (t : time_utc), 
+    has_to_string.to_string t.seconds_since_start_of_epoch
+⟩
+
+-- TODO: come up with an actual definition for UUID type
+def uuid : Type := ℕ
+
+instance : has_repr uuid := ⟨begin
+  intro u,
+  simp only [uuid] at u,
+  exact has_repr.repr u,
+end⟩
+
+structure mod_report {c : Type u → Type u} [collection.has_collection c] : Type u :=
+(time : time_utc)
+(score : fin 11)
+(id : uuid)
+(contributing_factors : c contributing_factor)
+
+namespace mod_report
+
+def get_repr_instance (c : Type u → Type u) [collection.has_collection c] [has_repr (c contributing_factor)]
+: has_repr (@mod_report c _)
+:= ⟨
+  λ (mr : mod_report),
+    "{time: " ++ has_repr.repr mr.time ++
+    ", score: " ++ has_repr.repr mr.score ++
+    ", uuid: " ++ has_repr.repr mr.id ++
+    ", contributing_factors: " ++ has_repr.repr mr.contributing_factors ++ "}"
+⟩
+
+-- ACTIONS
+
+def set_time {c : Type u → Type u} [hc : collection.has_collection c] : @mod_report c hc → time_utc → @mod_report c hc
+| ⟨t₀, s, u, cf⟩ t := ⟨t, s, u, cf⟩
+
+def set_score {c : Type u → Type u} [hc : collection.has_collection c] : @mod_report c hc → fin 11 → @mod_report c hc
+| ⟨t, s₀, u, cf⟩ s := ⟨t, s, u, cf⟩
+
+def set_uuid {c : Type u → Type u} [hc : collection.has_collection c] : @mod_report c hc → uuid → @mod_report c hc
+| ⟨t, s, u₀, cf⟩ u := ⟨t, s, u, cf⟩
+
+def set_contributing_factors {c : Type u → Type u} [hc : collection.has_collection c] : @mod_report c hc → c contributing_factor → @mod_report c hc
+| ⟨t, s, u, cf₀⟩ cf := ⟨t, s, u, cf⟩
+
+end mod_report

--- a/jackson/src/mod/test.lean
+++ b/jackson/src/mod/test.lean
@@ -1,0 +1,26 @@
+import .contributing_factor
+import .mod_report
+import ..implementation.collection_list
+
+-- Contributing Factor tests
+def cf : contributing_factor := contributing_factor.patient_unnecessary_treatments
+
+#reduce contributing_factor.get_category cf -- patient
+#eval contributing_factor.get_description cf -- "Feeling pressured to give unnecessary/inappropriate test and/or treatments"
+
+-- Mod Report tests
+
+open mod_report
+
+instance : has_repr (@mod_report list _) := get_repr_instance list
+
+def mr₀ : @mod_report list _ := ⟨⟨44⟩, 3, nat.zero, [cf]⟩
+def mr₁ := set_time mr₀ ⟨44050⟩
+def mr₂ := set_score mr₁ 0
+def mr₃ := set_uuid mr₂ (nat.succ nat.zero)
+def mr₄ := set_contributing_factors mr₃ []
+#eval mr₀
+#eval mr₁
+#eval mr₂
+#eval mr₃
+#eval mr₄


### PR DESCRIPTION
I've made some helpful changes and additions to the Lean files in the `jackson` directory. These include:

- Fixing typos and errors in `concept/collection.lean` and `concept/trash.lean`
- Creating a successful proof that `(insert_0 ns) = [0,1,2,3]` at the end of `collection_and_trash/list_collection_test.lean`
- Creating a Lean implementation of the "contributing factor" concept in `mod/contributing_factor.lean`
- Creating a Lean implementation of the "mod report" concept in `mod/mod_report.lean`
- Creating tests of the two above implementations in `mod/test.lean`